### PR TITLE
Document human approval boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ work are still evolving.
 - [Integration map](docs/INTEGRATION_MAP.md)
 - [Futures reconstruction](docs/FUTURES_RECONSTRUCTION.md)
 - [RWA and agentic payments research](research/RWA_AGENTIC_PAYMENTS_WATCHLIST.md)
+- [Human approval boundaries](docs/HUMAN_APPROVAL_BOUNDARIES.md)
 - [Agentic payment receipt example](examples/agentic-payment-receipts/README.md)
 - [Exhibition kit](docs/EXHIBITION_KIT.md)
 - [Open-source publication notes](docs/IP_PUBLICATION.md)

--- a/docs/HUMAN_APPROVAL_BOUNDARIES.md
+++ b/docs/HUMAN_APPROVAL_BOUNDARIES.md
@@ -1,0 +1,70 @@
+# Human Approval Boundaries
+
+NanoClaw should make agent work easier without turning sensitive decisions into
+silent automation. This note defines actions that can be drafted by an agent but
+should remain human-approved before execution.
+
+## Always Human-Approved
+
+| Boundary | Why it matters | Agent role |
+| --- | --- | --- |
+| Wallet connection | A wallet can authorize custody, identity, payment, and signing flows. | Explain the request, prepare a checklist, and stop before connection. |
+| Payment execution | Money movement needs intent, amount, recipient, network, and fee review. | Draft a payment receipt and leave settlement as `pending`. |
+| NFT minting or transfer | Minting can create public claims, edition scarcity, and permanent metadata. | Prepare metadata, rights notes, and mint checklist only. |
+| Private asset publication | Collection source files and previews can expose rights, provenance, or relationship context. | Build public-safe metadata and request owner review. |
+| Custody or rights claims | Custody, ownership, licensing, and edition language can create legal expectations. | Separate factual catalog fields from claims that need review. |
+| DNS or production deployment | Domain and deployment changes alter public availability. | Prepare records, status notes, and rollback steps. |
+| Donations or sponsorships | Public support can imply endorsement or budget commitment. | Maintain a shortlist and rationale; do not spend. |
+| External comments or PRs | Low-context public outreach can create noise or reputational drag. | Draft narrow comments/patches tied to a concrete issue. |
+
+## Usually Safe For Agents
+
+- Drafting issues, discussions, release notes, and docs.
+- Updating research watchlists from public sources.
+- Creating JSON schemas and local examples without secrets.
+- Running validation, formatting, and link checks.
+- Preparing public/private publication boundaries.
+- Summarizing reactions and drafting replies.
+
+## Approval Receipt Pattern
+
+Use receipts to make the handoff visible:
+
+1. `draft`: agent proposes the action.
+2. `approved`: a human approves a specific action.
+3. `executed`: an approved tool performs the action.
+4. `void`: the proposal is cancelled or superseded.
+
+The receipt should describe the tool boundary in plain language. If the action
+touches money, custody, rights, publication, or public claims, the receipt is not
+authority by itself. It is an audit surface.
+
+## RWA And Provenance Boundary
+
+NanoClaw can study tokenized collateral and RWA infrastructure without becoming
+a tokenized fund or collateral protocol.
+
+For cultural collections, the useful lane is provenance:
+
+- what object exists;
+- which edition or catalog record describes it;
+- what was reviewed;
+- what was published;
+- which actions were explicitly approved.
+
+That is different from yield-bearing collateral, investment exposure, or
+regulated custody. NanoClaw documentation should keep those categories separate.
+
+## Public Reply Rule
+
+When someone reacts to NanoClaw research, reply only when there is something
+specific to answer:
+
+- a technical correction;
+- a concrete example;
+- a documentation suggestion;
+- a reproducible issue;
+- a narrow collaboration surface.
+
+Do not send generic greetings, investment language, partnership claims, or
+requests for confidential information.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -31,6 +31,8 @@ customize their own fork.
 - Public website and exhibition kit.
 - Integration notes with adjacent open-source projects.
 - RWA, agentic-payments, and provenance research notes.
+- Human approval boundaries for wallets, payments, minting, DNS, donations, and
+  private asset publication.
 
 ## Near-Term Roadmap
 

--- a/examples/agentic-payment-receipts/README.md
+++ b/examples/agentic-payment-receipts/README.md
@@ -18,6 +18,13 @@ any real payment or onchain step exists.
   source assets.
 - Make future x402 or wallet integrations auditable before they become active.
 
+## Examples
+
+- `nc-ph-2026-001-01-receipt.json`: draft provenance preview receipt.
+- `nc-collector-preview-request.json`: draft collector-preview request where
+  the agent can prepare public-safe metadata but cannot publish assets, connect
+  wallets, mint NFTs, or execute payment.
+
 ## Status Values
 
 - `draft`: a proposed action, not approved.

--- a/examples/agentic-payment-receipts/nc-collector-preview-request.json
+++ b/examples/agentic-payment-receipts/nc-collector-preview-request.json
@@ -1,0 +1,29 @@
+{
+  "receipt_id": "nc-collector-preview-request-001",
+  "status": "draft",
+  "created_at": "2026-05-04T09:00:00Z",
+  "project": "NanoClaw public-safe provenance examples",
+  "action": {
+    "type": "collector_preview_request",
+    "summary": "Draft request for a human-reviewed collector preview without publishing private source assets or executing payment.",
+    "tool_boundary": "The agent may prepare a preview checklist and public-safe metadata, but cannot publish assets, connect wallets, mint NFTs, or send payment."
+  },
+  "human_review": {
+    "required": true,
+    "reviewer": "collection_owner",
+    "decision": "pending"
+  },
+  "asset_reference": {
+    "object_id": "public-safe-example-object",
+    "public_asset": false,
+    "hash": "not_recorded_in_public_example"
+  },
+  "payment_reference": {
+    "required": false,
+    "rail": "none",
+    "amount": "0",
+    "currency": "N/A",
+    "settlement_status": "not_applicable"
+  },
+  "notes": "This example models the approval boundary for a future collector preview. It contains no private image, wallet address, token, transaction, or buyer data."
+}


### PR DESCRIPTION
## Summary

- add `docs/HUMAN_APPROVAL_BOUNDARIES.md`
- link the boundary note from the README and project status
- add a second wallet-free receipt example for collector preview requests

## Safety

- docs/examples only
- no wallet connection, payment, NFT minting, DNS change, donation, or external outreach
- no private collection assets, wallet addresses, local private paths, or source-photo references

## Checks

- JSON examples parse successfully
- git diff --check passes
- local scan found no private paths or collection assets in the changed public files