### PR TITLE
Document provenance receipt pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ work are still evolving.
 - [RWA and agentic payments research](research/RWA_AGENTIC_PAYMENTS_WATCHLIST.md)
 - [Human approval boundaries](docs/HUMAN_APPROVAL_BOUNDARIES.md)
 - [Cultural provenance is not yield-bearing RWA](docs/CULTURAL_PROVENANCE_NOT_RWA.md)
+- [Provenance receipts](docs/PROVENANCE_RECEIPTS.md)
 - [Agentic payment receipt example](examples/agentic-payment-receipts/README.md)
 - [Exhibition kit](docs/EXHIBITION_KIT.md)
 - [Open-source publication notes](docs/IP_PUBLICATION.md)

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -33,6 +33,7 @@ customize their own fork.
 - RWA, agentic-payments, and provenance research notes.
 - Human approval boundaries for wallets, payments, minting, DNS, donations, and
   private asset publication.
+- Provenance receipts for public-safe catalog and collector-preview drafts.
 
 ## Near-Term Roadmap
 
@@ -44,6 +45,8 @@ customize their own fork.
 6. Add publication governance notes for ideas, docs, and AI-assisted work.
 7. Keep the RWA/agentic-payments research track current without making
    financial, custody, or partnership claims.
+8. Expand public-safe provenance receipts before any collection publication,
+   payment rail, or minting workflow.
 
 ## Contribution Fit
 

--- a/docs/PROVENANCE_RECEIPTS.md
+++ b/docs/PROVENANCE_RECEIPTS.md
@@ -1,0 +1,71 @@
+# Provenance Receipts
+
+Status: draft public pattern.
+Updated: 2026-05-04.
+
+NanoClaw uses provenance receipts to describe reviewable cultural-collection
+actions without turning them into payments, custody claims, or investment
+claims. A receipt is a small audit record for what an agent proposed, what a
+human reviewed, and what stayed private.
+
+## What A Receipt Can Prove
+
+| Field | Useful public meaning | Not a claim of |
+| --- | --- | --- |
+| `receipt_id` | Stable reference for a draft or reviewed action. | Ownership, title, or legal registration. |
+| `status` | Whether the action is draft, approved, executed, or void. | Permission to bypass human review. |
+| `asset_reference` | Public-safe object id and optional hash reference. | Publication of the source asset. |
+| `human_review` | Who must review the action class and whether a decision exists. | Legal advice or rights clearance by itself. |
+| `payment_reference` | Whether a payment rail is relevant to the proposed action. | Settlement, wallet control, or custody. |
+
+## Safe Public Uses
+
+- Catalog-entry review before publishing a public page.
+- Collector-preview request where source files stay private.
+- Edition metadata draft before any minting decision.
+- Receipt for a docs-only or research-only publication action.
+- Void receipt when a draft is cancelled or superseded.
+
+## Stop Before
+
+Receipts should stop and ask for explicit human confirmation before:
+
+- publishing private images or source files;
+- connecting a wallet;
+- minting, transferring, listing, or burning an NFT;
+- sending or requesting payment;
+- changing DNS or production deployment settings;
+- making custody, partnership, investment, yield, or guaranteed-value claims.
+
+## Public-Safe Asset References
+
+Use public-safe identifiers instead of private file names or local paths:
+
+```json
+{
+  "object_id": "public-safe-example-object",
+  "public_asset": false,
+  "hash": "not_recorded_in_public_example"
+}
+```
+
+If a hash is used, hash only a reviewed artifact that is allowed to be
+referenced publicly. Do not publish hashes that reveal a private source file,
+private filename, unreleased collection title, buyer data, or wallet data.
+
+## Status Flow
+
+1. `draft`: the agent prepared a proposed action.
+2. `approved`: a human approved a specific action and boundary.
+3. `executed`: an approved action was performed by an approved tool.
+4. `void`: the proposal was cancelled or replaced.
+
+The receipt is not an authority surface. It is a review trail. If the action
+touches money, custody, rights, minting, private assets, or public claims, the
+receipt should point to the required human approval instead of replacing it.
+
+## Example
+
+See `examples/agentic-payment-receipts/nc-public-catalog-entry-review.json` for
+a catalog-entry review receipt that contains no private asset, wallet address,
+payment, mint, or collector data.

--- a/docs/PUBLICATION_PACK.md
+++ b/docs/PUBLICATION_PACK.md
@@ -13,6 +13,7 @@ what should stay private until review.
 | `research/RWA_AGENTIC_PAYMENTS_WATCHLIST.md` | Shows that NanoClaw follows serious RWA, agentic-payments, and decentralized AI infrastructure. | Verify links and remove any source that looks unofficial. |
 | `research/RWA_AGENTIC_PAYMENTS_SCENARIOS.md` | Gives the project a thoughtful futures/research layer with seven scenarios. | Keep "not investment advice" language. |
 | `examples/agentic-payment-receipts/` | Demonstrates provenance/payment-action receipts without spending money. | Confirm examples contain no private asset URL, wallet address, or legal claim. |
+| `docs/PROVENANCE_RECEIPTS.md` | Explains the public-safe receipt vocabulary for collection review, catalog entries, and edition drafts. | Confirm it does not imply custody, minting, payment, ownership transfer, or rights clearance. |
 | `docs/PUBLICATION_PACK.md` | Makes the repo's publication boundary explicit. | Update this list as the public/private split changes. |
 
 ## Keep Private For Now
@@ -35,7 +36,9 @@ examples/
     README.md
     receipt.schema.json
     nc-ph-2026-001-01-receipt.json
+    nc-public-catalog-entry-review.json
 docs/
+  PROVENANCE_RECEIPTS.md
   PUBLICATION_PACK.md
 ```
 

--- a/examples/agentic-payment-receipts/README.md
+++ b/examples/agentic-payment-receipts/README.md
@@ -24,6 +24,11 @@ any real payment or onchain step exists.
 - `nc-collector-preview-request.json`: draft collector-preview request where
   the agent can prepare public-safe metadata but cannot publish assets, connect
   wallets, mint NFTs, or execute payment.
+- `nc-public-catalog-entry-review.json`: draft catalog-entry review where the
+  agent can prepare a public-safe record but cannot publish private source
+  assets or make custody, rights, payment, or edition claims.
+
+See also: [Provenance Receipts](../../docs/PROVENANCE_RECEIPTS.md).
 
 ## Status Values
 

--- a/examples/agentic-payment-receipts/nc-public-catalog-entry-review.json
+++ b/examples/agentic-payment-receipts/nc-public-catalog-entry-review.json
@@ -1,0 +1,29 @@
+{
+  "receipt_id": "nc-public-catalog-entry-review-001",
+  "status": "draft",
+  "created_at": "2026-05-04T12:00:00Z",
+  "project": "NanoClaw public-safe provenance examples",
+  "action": {
+    "type": "public_catalog_entry_review",
+    "summary": "Draft a public-safe catalog entry for human review without publishing private source assets or making custody, rights, payment, or edition claims.",
+    "tool_boundary": "The agent may prepare metadata, a review checklist, and a draft publication note. It cannot publish images, reveal local paths, connect wallets, mint NFTs, request payment, or claim ownership transfer."
+  },
+  "human_review": {
+    "required": true,
+    "reviewer": "collection_owner",
+    "decision": "pending"
+  },
+  "asset_reference": {
+    "object_id": "public-safe-example-object",
+    "public_asset": false,
+    "hash": "not_recorded_in_public_example"
+  },
+  "payment_reference": {
+    "required": false,
+    "rail": "none",
+    "amount": "0",
+    "currency": "N/A",
+    "settlement_status": "not_applicable"
+  },
+  "notes": "This receipt documents a review boundary only. It contains no private asset, local file path, wallet address, token, transaction, price, buyer data, or legal rights claim."
+}

--- a/research/RWA_AGENTIC_PAYMENTS_SCENARIOS.md
+++ b/research/RWA_AGENTIC_PAYMENTS_SCENARIOS.md
@@ -34,6 +34,8 @@ The practical near-term work:
 - keep raw collection assets private until reviewed;
 - publish public metadata and previews only after rights review;
 - build signed or hash-based receipts before any minting;
+- publish public-safe provenance receipts before any collection publication,
+  payment rail, or minting workflow;
 - use GitHub for open research, catalog schemas, and reproducible runbooks;
 - treat wallet/payment integrations as human-approved tools, not autonomous
   actions.


### PR DESCRIPTION
## Summary

- add a public-safe provenance receipt vocabulary
- add a catalog-entry review receipt example
- link the pattern from README, publication notes, project status, and research scenarios

## Safety

- docs/examples only
- no private assets, local paths, wallet data, minting, payments, DNS, custody, partnership, or investment claims

## Checks

- npm ci
- npm test -- --run
- JSON/schema smoke check passes
- targeted secret/path scan passes