### PR TITLE
docs: add collection schema examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ work are still evolving.
 - [Cultural provenance is not yield-bearing RWA](docs/CULTURAL_PROVENANCE_NOT_RWA.md)
 - [Provenance receipts](docs/PROVENANCE_RECEIPTS.md)
 - [Agentic payment receipt example](examples/agentic-payment-receipts/README.md)
+- [Collection schema examples](examples/collection-schemas/README.md)
 - [Exhibition kit](docs/EXHIBITION_KIT.md)
 - [Open-source publication notes](docs/IP_PUBLICATION.md)
 - [Website status](docs/WEBSITE_STATUS.md)

--- a/docs/PROVENANCE_RECEIPTS.md
+++ b/docs/PROVENANCE_RECEIPTS.md
@@ -69,3 +69,5 @@ receipt should point to the required human approval instead of replacing it.
 See `examples/agentic-payment-receipts/nc-public-catalog-entry-review.json` for
 a catalog-entry review receipt that contains no private asset, wallet address,
 payment, mint, or collector data.
+
+For structured catalog and edition drafts, see `examples/collection-schemas/`.

--- a/docs/PUBLICATION_PACK.md
+++ b/docs/PUBLICATION_PACK.md
@@ -13,6 +13,7 @@ what should stay private until review.
 | `research/RWA_AGENTIC_PAYMENTS_WATCHLIST.md` | Shows that NanoClaw follows serious RWA, agentic-payments, and decentralized AI infrastructure. | Verify links and remove any source that looks unofficial. |
 | `research/RWA_AGENTIC_PAYMENTS_SCENARIOS.md` | Gives the project a thoughtful futures/research layer with seven scenarios. | Keep "not investment advice" language. |
 | `examples/agentic-payment-receipts/` | Demonstrates provenance/payment-action receipts without spending money. | Confirm examples contain no private asset URL, wallet address, or legal claim. |
+| `examples/collection-schemas/` | Provides public-safe catalog object and edition draft schemas. | Confirm examples contain no private images, prices, buyer data, wallet data, or rights-clearance claims. |
 | `docs/PROVENANCE_RECEIPTS.md` | Explains the public-safe receipt vocabulary for collection review, catalog entries, and edition drafts. | Confirm it does not imply custody, minting, payment, ownership transfer, or rights clearance. |
 | `docs/PUBLICATION_PACK.md` | Makes the repo's publication boundary explicit. | Update this list as the public/private split changes. |
 
@@ -37,6 +38,11 @@ examples/
     receipt.schema.json
     nc-ph-2026-001-01-receipt.json
     nc-public-catalog-entry-review.json
+  collection-schemas/
+    catalog-object.schema.json
+    edition.schema.json
+    public-safe-catalog-object.example.json
+    limited-edition-draft.example.json
 docs/
   PROVENANCE_RECEIPTS.md
   PUBLICATION_PACK.md

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,3 +6,5 @@ This folder contains small, reviewable examples for future NanoClaw workflows.
 
 - `agentic-payment-receipts/`: a wallet-free JSON receipt format for
   human-approved agentic payment, provenance, and collector-access workflows.
+- `collection-schemas/`: public-safe catalog object and edition draft schemas
+  for review before publication, minting, or collector access.

--- a/examples/collection-schemas/README.md
+++ b/examples/collection-schemas/README.md
@@ -1,0 +1,24 @@
+# Collection Schemas
+
+Status: draft public examples.
+
+These schemas describe public-safe cultural collection records. They are meant
+for reviewable catalog and edition metadata, not for publishing private assets,
+minting NFTs, transferring rights, or making investment claims.
+
+## Schemas
+
+- `catalog-object.schema.json`: a public-safe catalog object record.
+- `edition.schema.json`: an edition metadata draft before any minting or sale.
+
+## Examples
+
+- `public-safe-catalog-object.example.json`: placeholder catalog object with no
+  private image, local path, buyer data, price, wallet address, or rights claim.
+- `limited-edition-draft.example.json`: placeholder edition draft with human
+  review still pending.
+
+## Rule
+
+Use these records to prepare review. Do not treat them as proof of ownership,
+rights clearance, custody, minting, payment, or investment value.

--- a/examples/collection-schemas/catalog-object.schema.json
+++ b/examples/collection-schemas/catalog-object.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nanoclaw.website/schemas/catalog-object.schema.json",
+  "title": "NanoClaw Public-Safe Catalog Object",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "object_id",
+    "status",
+    "title",
+    "collection",
+    "public_media",
+    "rights_review",
+    "publication_boundary"
+  ],
+  "properties": {
+    "object_id": {
+      "type": "string",
+      "pattern": "^nc-[a-z0-9-]+$"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "reviewed", "published", "withdrawn"]
+    },
+    "title": {
+      "type": "string"
+    },
+    "collection": {
+      "type": "string"
+    },
+    "public_media": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["available", "kind", "uri"],
+      "properties": {
+        "available": {
+          "type": "boolean"
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["none", "thumbnail", "preview", "metadata_only"]
+        },
+        "uri": {
+          "type": "string"
+        }
+      }
+    },
+    "rights_review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "status", "reviewer"],
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "reviewed", "not_applicable"]
+        },
+        "reviewer": {
+          "type": "string"
+        }
+      }
+    },
+    "publication_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["private_source_assets", "buyer_data", "wallet_data", "claims"],
+      "properties": {
+        "private_source_assets": {
+          "type": "string"
+        },
+        "buyer_data": {
+          "type": "string"
+        },
+        "wallet_data": {
+          "type": "string"
+        },
+        "claims": {
+          "type": "string"
+        }
+      }
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}

--- a/examples/collection-schemas/edition.schema.json
+++ b/examples/collection-schemas/edition.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nanoclaw.website/schemas/edition.schema.json",
+  "title": "NanoClaw Edition Draft",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "edition_id",
+    "status",
+    "source_object_id",
+    "edition_size",
+    "minting",
+    "rights_review",
+    "human_approval"
+  ],
+  "properties": {
+    "edition_id": {
+      "type": "string",
+      "pattern": "^nc-ed-[a-z0-9-]+$"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "reviewed", "published", "void"]
+    },
+    "source_object_id": {
+      "type": "string"
+    },
+    "edition_size": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "minting": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["planned", "network", "contract", "status"],
+      "properties": {
+        "planned": {
+          "type": "boolean"
+        },
+        "network": {
+          "type": "string"
+        },
+        "contract": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["not_planned", "draft_only", "requires_approval", "completed"]
+        }
+      }
+    },
+    "rights_review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "status"],
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "reviewed", "not_applicable"]
+        }
+      }
+    },
+    "human_approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required_before_mint", "decision"],
+      "properties": {
+        "required_before_mint": {
+          "type": "boolean"
+        },
+        "decision": {
+          "type": "string",
+          "enum": ["pending", "approved", "rejected"]
+        }
+      }
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}

--- a/examples/collection-schemas/limited-edition-draft.example.json
+++ b/examples/collection-schemas/limited-edition-draft.example.json
@@ -1,0 +1,21 @@
+{
+  "edition_id": "nc-ed-public-safe-001",
+  "status": "draft",
+  "source_object_id": "nc-public-safe-object-001",
+  "edition_size": 13,
+  "minting": {
+    "planned": false,
+    "network": "none",
+    "contract": "none",
+    "status": "draft_only"
+  },
+  "rights_review": {
+    "required": true,
+    "status": "pending"
+  },
+  "human_approval": {
+    "required_before_mint": true,
+    "decision": "pending"
+  },
+  "notes": "Public-safe edition draft. No price, wallet, buyer, mint, transfer, or listing data."
+}

--- a/examples/collection-schemas/public-safe-catalog-object.example.json
+++ b/examples/collection-schemas/public-safe-catalog-object.example.json
@@ -1,0 +1,23 @@
+{
+  "object_id": "nc-public-safe-object-001",
+  "status": "draft",
+  "title": "Public-Safe Example Object",
+  "collection": "NanoClaw public examples",
+  "public_media": {
+    "available": false,
+    "kind": "metadata_only",
+    "uri": ""
+  },
+  "rights_review": {
+    "required": true,
+    "status": "pending",
+    "reviewer": "collection_owner"
+  },
+  "publication_boundary": {
+    "private_source_assets": "not_included",
+    "buyer_data": "not_included",
+    "wallet_data": "not_included",
+    "claims": "no ownership transfer, custody, yield, investment, or rights-clearance claim"
+  },
+  "notes": "Placeholder record for schema testing only."
+}


### PR DESCRIPTION
## Summary

- add public-safe catalog object and edition draft JSON schemas
- add placeholder examples with no private assets, prices, buyer data, wallet data, minting, listing, or rights-clearance claims
- link the schemas from README, examples index, provenance receipts, and publication pack

## Safety

- docs/examples only
- no private photos or source assets
- no wallet addresses, seed phrases, tokens, buyer data, prices, payment details, mint/listing data, or local paths
- no partnership, custody, yield, investment, guaranteed-value, or rights-clearance claims

## Checks

- all JSON files parse successfully
- git diff --check passes
- targeted scan found no real secrets, wallet data, private asset paths, or local workspace paths in the staged public files