### PR TITLE
docs: add ecosystem infrastructure model

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ skills-as-branches model are usable; new integrations and public presentation
 work are still evolving.
 
 - [Project status and roadmap](docs/PROJECT_STATUS.md)
+- [Ecosystem operating model](docs/ECOSYSTEM_OPERATING_MODEL.md)
 - [Safety model](docs/SAFETY_MODEL.md)
 - [Integration map](docs/INTEGRATION_MAP.md)
+- [Integration surfaces](docs/INTEGRATION_SURFACES.md)
+- [Weekly operating loop](docs/WEEKLY_OPERATING_LOOP.md)
 - [Futures reconstruction](docs/FUTURES_RECONSTRUCTION.md)
 - [RWA and agentic payments research](research/RWA_AGENTIC_PAYMENTS_WATCHLIST.md)
 - [Human approval boundaries](docs/HUMAN_APPROVAL_BOUNDARIES.md)

--- a/docs/ECOSYSTEM_OPERATING_MODEL.md
+++ b/docs/ECOSYSTEM_OPERATING_MODEL.md
@@ -1,0 +1,73 @@
+# Ecosystem Operating Model
+
+NanoClaw uses GitHub as a public engineering memory, not only as a source-code
+host. The repository should show what the project is, what it is learning, what
+is safe to publish, and which actions must remain human-approved.
+
+## What GitHub Provides
+
+| Surface | Role | Useful output |
+| --- | --- | --- |
+| Pull requests | Reviewable change history | Docs, schemas, examples, small fixes |
+| Issues | Public work tracking | Research questions, website tasks, follow-up notes |
+| Discussions | Low-pressure ecosystem questions | Approval-boundary and integration feedback |
+| Releases | Public milestones | Versioned research/docs packages |
+| GitHub Pages | Public website surface | `nanoclaw.website` after DNS/HTTPS setup |
+| Examples | Reusable patterns | Receipts, catalog schemas, safe metadata drafts |
+| Research notes | Structured learning | RWA, x402, MCP, provenance, DeepTech tracking |
+
+## Operating Principle
+
+NanoClaw should become visible by being useful:
+
+1. read before acting;
+2. publish small reviewable artifacts;
+3. ask precise questions only when docs do not already answer them;
+4. contribute docs/examples instead of generic outreach;
+5. keep wallet, payment, minting, DNS, private assets, legal claims, and
+   pricing behind explicit human approval.
+
+## Public And Private Split
+
+GitHub can contain public-safe structure:
+
+- schemas;
+- examples with placeholders;
+- provenance receipt formats;
+- publication checklists;
+- research notes;
+- integration maps;
+- release history.
+
+GitHub must not contain:
+
+- source collection media;
+- private buyer or collector data;
+- wallet credentials, wallet addresses, seed phrases, API keys, or webhooks;
+- prices, auction strategy, or guaranteed-value language;
+- claims of partnership, custody, rights clearance, regulated financial
+  activity, or investment performance.
+
+## Current Public Tracks
+
+| Track | Public artifact |
+| --- | --- |
+| Runtime and sandboxing | `docs/SAFETY_MODEL.md`, `docs/SPEC.md` |
+| Human approvals | `docs/HUMAN_APPROVAL_BOUNDARIES.md` |
+| RWA and agentic payments | `research/RWA_AGENTIC_PAYMENTS_WATCHLIST.md` |
+| Futures reconstruction | `research/RWA_AGENTIC_PAYMENTS_SCENARIOS.md`, `docs/FUTURES_RECONSTRUCTION.md` |
+| Provenance receipts | `docs/PROVENANCE_RECEIPTS.md`, `examples/agentic-payment-receipts/` |
+| Collection schemas | `examples/collection-schemas/` |
+| Public/private publication | `docs/PUBLICATION_PACK.md` |
+| Ecosystem integrations | `docs/INTEGRATION_MAP.md`, `docs/INTEGRATION_SURFACES.md` |
+
+## Success Criteria
+
+NanoClaw's GitHub presence is healthy when:
+
+- the README points to clear current work;
+- issues and releases tell a coherent story;
+- examples are public-safe and reusable;
+- external comments and PRs are narrow and useful;
+- private collection assets stay private;
+- each risky action has an explicit human-approval boundary.

--- a/docs/INTEGRATION_MAP.md
+++ b/docs/INTEGRATION_MAP.md
@@ -21,6 +21,11 @@ open-source projects rather than broad promotional outreach.
 | `ITSpecialist111/ai_automation_suggester` | AI-generated Home Assistant suggestions | Study suggestion-first UX.                |
 | `winstonkoh87/Athena-Public`              | Local-first agent OS / memory           | Compare inspectable memory patterns.      |
 | `osendowment/foundation`                  | Open-source funding                     | Learn small sponsor / donor patterns.     |
+| `x402-foundation/x402`                    | HTTP-native agentic payments            | Maintain narrow docs-only contribution path. |
+| `modelcontextprotocol/modelcontextprotocol` | Tool and context protocol vocabulary   | Study approval-boundary and tool-call language. |
+| `cloudflare/agents`                       | Edge agent runtime and state            | Study durable workflows and permission boundaries. |
+| `coinbase/agentkit`                       | Wallet-capable agent tooling            | Study wallet approval boundaries without wallet actions. |
+| `open-telemetry/opentelemetry-specification` | Traces and event vocabulary           | Borrow action-receipt and audit language. |
 
 ## First Questions To Ask
 
@@ -46,3 +51,9 @@ is:
 
 Read first. Ask one narrow question. Turn useful answers into docs, tests, or
 skills. Avoid drive-by promotion.
+
+## Related Operating Docs
+
+- [Ecosystem operating model](ECOSYSTEM_OPERATING_MODEL.md)
+- [Integration surfaces](INTEGRATION_SURFACES.md)
+- [Weekly operating loop](WEEKLY_OPERATING_LOOP.md)

--- a/docs/INTEGRATION_SURFACES.md
+++ b/docs/INTEGRATION_SURFACES.md
@@ -1,0 +1,75 @@
+# Integration Surfaces
+
+NanoClaw's integrations are organized as surfaces. A surface can be public,
+internal, or future-facing. Each surface has a different safety boundary.
+
+## Surface Map
+
+| Surface | Direction | Purpose | Boundary |
+| --- | --- | --- | --- |
+| GitHub | Public | Code, docs, schemas, examples, issues, PRs, releases | No secrets, private assets, wallet data, pricing, or legal/financial claims |
+| Bitrix24 | Internal | Tasks, checklists, deadlines, files, operational status | No public claims; keep credentials out of shared files |
+| GitHub Pages | Public website | Documentation and presentation layer for `nanoclaw.website` | DNS/HTTPS changes require explicit approval |
+| Collection catalog | Private plus public-safe excerpts | Organize objects, editions, certificates, and provenance | Source media and collector data stay private |
+| NFT platforms | Future external surface | Possible minting/listing after review | No wallet, minting, listing, transfer, or pricing without explicit approval |
+| x402 and agentic payments | Public research plus external docs PRs | Study HTTP-native payments and agent approval boundaries | No payment execution or yield/custody claims |
+| MCP and AgentKit | Public research plus optional docs PRs | Tool protocols, wallet-capable agents, approval vocabulary | No automatic wallet actions |
+| OpenTelemetry | Public research vocabulary | Receipts, traces, action logs, audit language | No claim of formal compliance unless implemented |
+| DeepTech repos | Public study/contribution layer | Materials, medicine, robotics, sensors, networks | Read first; contribute only precise docs/examples |
+
+## Mutual Integration Pattern
+
+```text
+GitHub
+  public source of truth for docs, schemas, examples, releases
+
+Bitrix24
+  internal task/control layer with links back to GitHub
+
+nanoclaw.website
+  public presentation layer generated from or linked to GitHub materials
+
+Collection/NFT infrastructure
+  private source assets plus public-safe metadata, receipts, and certificates
+
+x402 / MCP / AgentKit / OpenTelemetry
+  external vocabularies and protocols that inform NanoClaw examples
+```
+
+## Integration Rules
+
+### GitHub To Bitrix24
+
+- GitHub PRs, issues, releases, and discussions can be linked from Bitrix24
+  tasks.
+- Bitrix24 should track deadlines and checklists.
+- Bitrix24 should not create public comments automatically.
+
+### GitHub To Website
+
+- GitHub remains the source of public docs and release history.
+- The website can present curated pages, catalog previews, and project status.
+- DNS and HTTPS changes require explicit approval.
+
+### GitHub To Collection/NFT
+
+- GitHub can publish schemas and examples.
+- GitHub can publish public-safe provenance and edition receipt templates.
+- GitHub should not publish source images, full-resolution files, private
+  collector data, wallet data, or pricing.
+
+### GitHub To External Open Source
+
+- External work should be docs-only unless there is a very clear reason.
+- Prefer one useful PR over many symbolic forks.
+- Do not imply partnership, endorsement, investment advice, custody, or
+  production readiness.
+
+## Near-Term Integration Priorities
+
+1. Keep NanoClaw releases coherent and owner-authored.
+2. Restore Bitrix24 task updates after the internal credential is refreshed.
+3. Prepare `nanoclaw.website` DNS/HTTPS checklist without changing DNS yet.
+4. Study MCP and Cloudflare Agents for one precise docs or vocabulary gap.
+5. Keep x402 PR #2186 monitored without generic follow-up comments.
+6. Expand public-safe collection schemas only after private/public review.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -14,6 +14,9 @@ customize their own fork.
 - Skills-as-branches contribution model: active.
 - Public website: GitHub Pages is configured; DNS for `nanoclaw.website` is
   still pending.
+- Ecosystem operating model: active as a public docs layer.
+- Integration surfaces: active as a public map for GitHub, Bitrix24, website,
+  collection/NFT, x402/MCP/AgentKit, OpenTelemetry, and DeepTech links.
 
 ## Stable Enough To Try
 
@@ -34,6 +37,8 @@ customize their own fork.
 - Human approval boundaries for wallets, payments, minting, DNS, donations, and
   private asset publication.
 - Provenance receipts for public-safe catalog and collector-preview drafts.
+- Operational cadence for owner-authored public docs, releases, and external
+  docs-only contributions.
 
 ## Near-Term Roadmap
 
@@ -47,6 +52,8 @@ customize their own fork.
    financial, custody, or partnership claims.
 8. Expand public-safe provenance receipts before any collection publication,
    payment rail, or minting workflow.
+9. Use the weekly operating loop to keep activity useful, reviewable, and
+   low-noise.
 
 ## Contribution Fit
 

--- a/docs/PUBLICATION_PACK.md
+++ b/docs/PUBLICATION_PACK.md
@@ -16,6 +16,9 @@ what should stay private until review.
 | `examples/collection-schemas/` | Provides public-safe catalog object and edition draft schemas. | Confirm examples contain no private images, prices, buyer data, wallet data, or rights-clearance claims. |
 | `docs/PROVENANCE_RECEIPTS.md` | Explains the public-safe receipt vocabulary for collection review, catalog entries, and edition drafts. | Confirm it does not imply custody, minting, payment, ownership transfer, or rights clearance. |
 | `docs/PUBLICATION_PACK.md` | Makes the repo's publication boundary explicit. | Update this list as the public/private split changes. |
+| `docs/ECOSYSTEM_OPERATING_MODEL.md` | Explains why GitHub is the public engineering memory for NanoClaw. | Keep public/private and human-approval boundaries explicit. |
+| `docs/INTEGRATION_SURFACES.md` | Maps GitHub, Bitrix24, website, collection/NFT, x402/MCP/AgentKit, OpenTelemetry, and DeepTech surfaces. | Avoid implying partnerships or production integrations that do not exist. |
+| `docs/WEEKLY_OPERATING_LOOP.md` | Defines the low-noise weekly cadence for public work. | Keep risky actions behind explicit human approval. |
 
 ## Keep Private For Now
 
@@ -44,6 +47,9 @@ examples/
     public-safe-catalog-object.example.json
     limited-edition-draft.example.json
 docs/
+  ECOSYSTEM_OPERATING_MODEL.md
+  INTEGRATION_SURFACES.md
+  WEEKLY_OPERATING_LOOP.md
   PROVENANCE_RECEIPTS.md
   PUBLICATION_PACK.md
 ```

--- a/docs/WEEKLY_OPERATING_LOOP.md
+++ b/docs/WEEKLY_OPERATING_LOOP.md
@@ -1,0 +1,84 @@
+# Weekly Operating Loop
+
+This loop keeps NanoClaw active without manufacturing noise. It is designed for
+small public improvements, safe research, and clear human approval boundaries.
+
+## Weekly Goals
+
+| Goal | Output |
+| --- | --- |
+| Keep the repository alive | One small docs, schema, example, or issue update |
+| Maintain public trust | Releases and issues that explain what changed |
+| Learn from adjacent ecosystems | One local research note or mapping note |
+| Contribute externally with restraint | At most one precise docs-only PR when a real gap exists |
+| Protect private assets | Run public/private and secret scans before publishing |
+
+## Cadence
+
+### Daily
+
+1. Check open NanoClaw PRs, issues, discussions, and releases.
+2. Check external PRs, especially x402 PR #2186.
+3. Reply only to concrete human maintainer or user questions.
+4. Update local monitoring notes when there is a real state change.
+
+### Twice Per Week
+
+1. Improve one public-safe NanoClaw document or example.
+2. Review one adjacent ecosystem:
+   - x402;
+   - MCP;
+   - Cloudflare Agents;
+   - AgentKit;
+   - OpenTelemetry;
+   - materials, medicine, robotics, sensors, or edge-network projects.
+3. Extract a lesson into NanoClaw docs before opening any external PR.
+
+### Weekly
+
+1. Publish or prepare one coherent public milestone.
+2. Update the relevant issue or release notes.
+3. Refresh the integration map and DeepTech queue.
+4. Review private/public boundaries for collection and NFT materials.
+5. Confirm no risky action happened without explicit human approval.
+
+## Human-Approved Actions
+
+These actions must remain separately approved:
+
+- wallet connection;
+- minting;
+- transfers or listings;
+- payments or donations;
+- DNS changes;
+- publishing private collection assets;
+- pricing or buyer outreach;
+- legal, custody, rights-clearance, yield, investment, or partnership claims.
+
+## Good Public Actions
+
+- owner-authored docs PRs;
+- schema examples with fake placeholder data;
+- release notes for public-safe milestones;
+- issue updates with concrete links;
+- external docs-only PRs that fix one specific gap;
+- short maintainer replies that answer an exact question.
+
+## Bad Public Actions
+
+- generic greetings;
+- mass forks;
+- mass comments;
+- vague partnership language;
+- broad investment language;
+- public claims that outrun the implementation;
+- publishing private assets to create activity.
+
+## Current Weekly Priority
+
+1. Keep `v0.1.3-collection-schemas` visible as the latest collection/provenance
+   milestone.
+2. Monitor x402 PR #2186.
+3. Create a local MCP/Cloudflare Agents vocabulary note.
+4. Prepare the next owner-authored docs PR only if the change is narrow and
+   public-safe.


### PR DESCRIPTION
## Summary
- add an ecosystem operating model for GitHub as NanoClaw's public engineering memory
- add integration surfaces for GitHub, Bitrix24, website, collection/NFT, x402/MCP/AgentKit, OpenTelemetry, and DeepTech
- add a weekly operating loop for low-noise public activity
- link the new docs from README, project status, integration map, and publication pack

## Safety
- docs-only update
- no private collection assets
- no wallet data, webhook URLs, buyer data, payment details, pricing, or legal/financial claims

## Checks
- git diff --check passes
- targeted secrets/private-data scan found only safety wording false positives