### PR TITLE
docs: add evidence education and trust layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ work are still evolving.
 
 - [Project status and roadmap](docs/PROJECT_STATUS.md)
 - [Ecosystem operating model](docs/ECOSYSTEM_OPERATING_MODEL.md)
+- [Evidence and source index](docs/EVIDENCE_AND_SOURCE_INDEX.md)
+- [Curriculum and learning paths](docs/CURRICULUM_AND_LEARNING_PATHS.md)
+- [Contributor entrypoints](docs/CONTRIBUTOR_ENTRYPOINTS.md)
+- [Trust architecture](docs/TRUST_ARCHITECTURE.md)
 - [Safety model](docs/SAFETY_MODEL.md)
 - [Integration map](docs/INTEGRATION_MAP.md)
 - [Integration surfaces](docs/INTEGRATION_SURFACES.md)

--- a/docs/CONTRIBUTOR_ENTRYPOINTS.md
+++ b/docs/CONTRIBUTOR_ENTRYPOINTS.md
@@ -1,0 +1,72 @@
+# Contributor Entrypoints
+
+NanoClaw should be easy to approach without requiring private context. This file
+maps the first useful actions for different kinds of contributors.
+
+## Entrypoints By Role
+
+| Role | Start here | Good first action |
+| --- | --- | --- |
+| Student | `docs/CURRICULUM_AND_LEARNING_PATHS.md` | Complete one exercise and open a docs clarification issue |
+| Developer | `docs/SPEC.md`, `docs/SAFETY_MODEL.md` | Improve setup docs or add a small test |
+| Researcher | `docs/EVIDENCE_AND_SOURCE_INDEX.md`, `research/` | Verify one source and suggest a citation improvement |
+| Maintainer | PR list, release notes, `docs/WEEKLY_OPERATING_LOOP.md` | Review a narrow docs/example PR |
+| Partner | README, releases, `docs/ECOSYSTEM_OPERATING_MODEL.md` | Ask one precise scope or integration question |
+| Collection collaborator | `examples/collection-schemas/`, `docs/PROVENANCE_RECEIPTS.md` | Review public/private metadata boundaries |
+
+## Good First Issues
+
+Good first issues should be:
+
+- public-safe;
+- small;
+- reviewable in one sitting;
+- free of private assets and credentials;
+- framed as docs, examples, tests, or source verification.
+
+Examples:
+
+- clarify one setup step;
+- verify one source in a research note;
+- add one glossary term;
+- improve one fake example;
+- add one safety boundary note;
+- report a broken link.
+
+## Feedback Requests
+
+When asking for feedback, be precise:
+
+- "Does this approval boundary match the documented x402 flow?"
+- "Is this schema field name clear for public-safe metadata?"
+- "Does this docs note overstate the integration?"
+- "Is this source primary enough to support the claim?"
+
+Avoid:
+
+- generic partnership requests;
+- mass invitations;
+- investment language;
+- claims of official endorsement;
+- requests that require maintainers to inspect private assets.
+
+## Review Checklist
+
+Before opening a PR or public comment:
+
+1. Is the change narrow?
+2. Is it supported by a source or local example?
+3. Does it avoid private assets and credentials?
+4. Does it avoid partnership, investment, custody, yield, pricing, or legal
+   claims?
+5. Can a maintainer review it quickly?
+
+## Maintainer Promise
+
+NanoClaw should respect maintainer time:
+
+- no generic comments;
+- no pressure for replies;
+- no broad roadmaps in someone else's issue tracker;
+- no hidden commercial ask;
+- no implied partnership.

--- a/docs/CURRICULUM_AND_LEARNING_PATHS.md
+++ b/docs/CURRICULUM_AND_LEARNING_PATHS.md
@@ -1,0 +1,121 @@
+# Curriculum And Learning Paths
+
+NanoClaw can serve as a small public learning lab for agent runtime safety,
+open-source contribution, provenance receipts, and public/private publication
+boundaries.
+
+## Audience
+
+| Audience | Entry point | Outcome |
+| --- | --- | --- |
+| Students | Glossary, exercises, simple docs tasks | Understand agent safety and GitHub workflow |
+| Developers | Architecture, examples, schemas, issues | Contribute small docs/tests/examples |
+| Researchers | Evidence index, watchlists, scenarios | Trace claims and compare protocols |
+| Maintainers | PRs, issues, contribution rules | Review narrow useful changes |
+| Partners | Releases, website, public-safe catalog docs | Understand scope without private access |
+
+## Curriculum Structure
+
+### Module 1: GitHub As Public Engineering Memory
+
+Topics:
+
+- commits, issues, PRs, discussions, releases;
+- why small reviewable changes matter;
+- how public activity differs from promotion.
+
+Exercise:
+
+- Read one NanoClaw release and identify the files, PR, issue update, and safety
+  boundary behind it.
+
+### Module 2: Agent Safety And Human Approval
+
+Topics:
+
+- container isolation;
+- suggestion versus execution;
+- human-approved actions;
+- wallet, payment, DNS, minting, and private asset boundaries.
+
+Exercise:
+
+- Classify ten hypothetical agent actions as `safe to draft`,
+  `safe to execute`, or `human approval required`.
+
+### Module 3: Provenance Receipts
+
+Topics:
+
+- receipt schemas;
+- public-safe catalog review;
+- edition drafts;
+- action logs and audit vocabulary.
+
+Exercise:
+
+- Create a fake public-safe provenance receipt using placeholder data only.
+
+### Module 4: Collection And Edition Schemas
+
+Topics:
+
+- catalog object schema;
+- edition schema;
+- public/private split;
+- certificate drafts.
+
+Exercise:
+
+- Validate a sample catalog object and remove any private fields before
+  publication.
+
+### Module 5: RWA, x402, And Agentic Payments
+
+Topics:
+
+- tokenized assets as research context;
+- x402-style payment boundaries;
+- wallet approval;
+- no automatic transfers, listing, minting, or financial claims.
+
+Exercise:
+
+- Write a research note that separates source-confirmed facts from NanoClaw
+  hypotheses.
+
+### Module 6: External Open-Source Contribution
+
+Topics:
+
+- reading maintainer docs;
+- finding one precise docs gap;
+- opening a small PR;
+- responding without generic outreach.
+
+Exercise:
+
+- Draft a docs-only PR description for a hypothetical one-line clarification.
+
+## Glossary
+
+| Term | Working definition |
+| --- | --- |
+| Agent receipt | A public-safe record of a proposed, reviewed, or completed agent action |
+| Approval boundary | The point where an agent must stop and ask for human confirmation |
+| Catalog object | A structured public-safe description of a collection item |
+| Edition | A limited publication unit derived from a catalog object |
+| Human-approved action | Any action that can create legal, financial, privacy, custody, or publication risk |
+| Public-safe metadata | Metadata that can be published without private assets, buyer data, wallet data, or legal claims |
+| Source verification | Checking a claim against primary docs, repos, specs, or maintainer statements |
+
+## Assessment
+
+A learner can use NanoClaw responsibly when they can:
+
+- explain why public claims need sources;
+- identify private fields in a catalog draft;
+- distinguish docs-only contribution from outreach;
+- write a safe issue update;
+- describe why wallet, minting, payment, DNS, and private asset actions need
+  explicit human approval.

--- a/docs/ECOSYSTEM_OPERATING_MODEL.md
+++ b/docs/ECOSYSTEM_OPERATING_MODEL.md
@@ -15,6 +15,8 @@ is safe to publish, and which actions must remain human-approved.
 | GitHub Pages | Public website surface | `nanoclaw.website` after DNS/HTTPS setup |
 | Examples | Reusable patterns | Receipts, catalog schemas, safe metadata drafts |
 | Research notes | Structured learning | RWA, x402, MCP, provenance, DeepTech tracking |
+| Source index | Evidence base | Citations, literature notes, verification states |
+| Curriculum | Education layer | Modules, exercises, glossary, entrypoints |
 
 ## Operating Principle
 
@@ -60,6 +62,9 @@ GitHub must not contain:
 | Collection schemas | `examples/collection-schemas/` |
 | Public/private publication | `docs/PUBLICATION_PACK.md` |
 | Ecosystem integrations | `docs/INTEGRATION_MAP.md`, `docs/INTEGRATION_SURFACES.md` |
+| Evidence and citations | `docs/EVIDENCE_AND_SOURCE_INDEX.md` |
+| Education and entrypoints | `docs/CURRICULUM_AND_LEARNING_PATHS.md`, `docs/CONTRIBUTOR_ENTRYPOINTS.md` |
+| Trust architecture | `docs/TRUST_ARCHITECTURE.md` |
 
 ## Success Criteria
 
@@ -70,4 +75,7 @@ NanoClaw's GitHub presence is healthy when:
 - examples are public-safe and reusable;
 - external comments and PRs are narrow and useful;
 - private collection assets stay private;
-- each risky action has an explicit human-approval boundary.
+- each risky action has an explicit human-approval boundary;
+- claims are backed by source-verification states;
+- students, developers, researchers, maintainers, and partners each have a
+  clear entrypoint.

--- a/docs/EVIDENCE_AND_SOURCE_INDEX.md
+++ b/docs/EVIDENCE_AND_SOURCE_INDEX.md
@@ -1,0 +1,73 @@
+# Evidence And Source Index
+
+NanoClaw should keep research claims traceable. This index defines how sources,
+citations, literature notes, and verification status should be recorded before
+they influence docs, examples, integrations, or public comments.
+
+## Purpose
+
+- Keep technical claims checkable.
+- Separate facts, interpretations, and future-facing hypotheses.
+- Make research useful for students, developers, researchers, maintainers, and
+  partners.
+- Avoid hype, fake authority, and implied partnerships.
+
+## Source Types
+
+| Type | Preferred examples | Use |
+| --- | --- | --- |
+| Primary documentation | Official project docs, API references, specifications | Implementation and integration notes |
+| Source repositories | README, examples, issues, PRs, releases | Open-source behavior and contribution fit |
+| Standards and specs | Protocol specs, security models, telemetry specs | Vocabulary and interoperability |
+| Academic literature | Papers, preprints, conference proceedings | Conceptual framing and research history |
+| Public company posts | Engineering blogs, product docs, official announcements | Current product signals |
+| Maintainer comments | Issue/PR replies, discussions | Project-specific intent and review feedback |
+
+## Verification States
+
+| State | Meaning | Public use |
+| --- | --- | --- |
+| `unverified` | Found but not checked against primary source | Do not cite as fact |
+| `primary-source-confirmed` | Checked against official docs, repo, spec, or maintainer statement | Safe for factual notes |
+| `secondary-source-context` | Useful commentary, not authoritative | Use only as context |
+| `hypothesis` | NanoClaw interpretation or future scenario | Label clearly |
+| `deprecated` | Source no longer current | Keep only for history |
+
+## Literature Index Template
+
+| Topic | Source | Type | Verification state | NanoClaw relevance | Follow-up |
+| --- | --- | --- | --- | --- | --- |
+| x402 payment flow | Official x402 docs or repo | Primary docs/source repo | `primary-source-confirmed` after review | Agentic payment boundaries | Keep PR #2186 monitored |
+| MCP tool vocabulary | MCP docs/spec repo | Specification/source repo | `unverified` until reviewed | Tool calls and approval language | Create local mapping note |
+| OpenTelemetry traces | OTel specification | Specification | `unverified` until reviewed | Action receipts and audit vocabulary | Extract receipt terms |
+
+## Claim Discipline
+
+Every public research or integration note should answer:
+
+1. What is the source?
+2. Is it primary or secondary?
+3. What exactly does it support?
+4. What is NanoClaw's interpretation?
+5. What remains speculative?
+6. What action, if any, follows from it?
+
+## Citation Rules
+
+- Prefer official docs, source repos, specs, and maintainer statements.
+- Link to exact docs, issues, PRs, releases, or files when possible.
+- Do not cite broad homepages when a precise source exists.
+- Do not treat marketing language as a technical guarantee.
+- Do not imply partnership, endorsement, custody, regulated status, yield, or
+  investment value unless a primary source explicitly supports the claim and
+  the claim is legally safe to make.
+
+## Relationship To Existing Research
+
+Use this index with:
+
+- `research/RWA_AGENTIC_PAYMENTS_WATCHLIST.md`
+- `research/RWA_AGENTIC_PAYMENTS_SCENARIOS.md`
+- `docs/INTEGRATION_SURFACES.md`
+- `docs/WEEKLY_OPERATING_LOOP.md`
+- `docs/TRUST_ARCHITECTURE.md`

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -15,6 +15,9 @@ customize their own fork.
 - Public website: GitHub Pages is configured; DNS for `nanoclaw.website` is
   still pending.
 - Ecosystem operating model: active as a public docs layer.
+- Evidence/source index: active as a public docs layer.
+- Curriculum and contributor entrypoints: active as a public docs layer.
+- Trust architecture: active as a public docs layer.
 - Integration surfaces: active as a public map for GitHub, Bitrix24, website,
   collection/NFT, x402/MCP/AgentKit, OpenTelemetry, and DeepTech links.
 
@@ -54,6 +57,8 @@ customize their own fork.
    payment rail, or minting workflow.
 9. Use the weekly operating loop to keep activity useful, reviewable, and
    low-noise.
+10. Keep source verification, curriculum, contributor entrypoints, and trust
+    architecture current as the project grows.
 
 ## Contribution Fit
 

--- a/docs/PUBLICATION_PACK.md
+++ b/docs/PUBLICATION_PACK.md
@@ -19,6 +19,10 @@ what should stay private until review.
 | `docs/ECOSYSTEM_OPERATING_MODEL.md` | Explains why GitHub is the public engineering memory for NanoClaw. | Keep public/private and human-approval boundaries explicit. |
 | `docs/INTEGRATION_SURFACES.md` | Maps GitHub, Bitrix24, website, collection/NFT, x402/MCP/AgentKit, OpenTelemetry, and DeepTech surfaces. | Avoid implying partnerships or production integrations that do not exist. |
 | `docs/WEEKLY_OPERATING_LOOP.md` | Defines the low-noise weekly cadence for public work. | Keep risky actions behind explicit human approval. |
+| `docs/EVIDENCE_AND_SOURCE_INDEX.md` | Tracks sources, literature notes, and verification states. | Separate primary-source facts from hypotheses. |
+| `docs/CURRICULUM_AND_LEARNING_PATHS.md` | Structures educational modules, exercises, and glossary. | Keep examples public-safe and non-credentialed. |
+| `docs/CONTRIBUTOR_ENTRYPOINTS.md` | Gives students, developers, researchers, maintainers, and partners a safe starting point. | Avoid private-only context and generic outreach. |
+| `docs/TRUST_ARCHITECTURE.md` | Defines evidence, reputation, operations, integration, and ethics boundaries. | Avoid hype, fake partnerships, and legal/financial overclaims. |
 
 ## Keep Private For Now
 
@@ -50,6 +54,10 @@ docs/
   ECOSYSTEM_OPERATING_MODEL.md
   INTEGRATION_SURFACES.md
   WEEKLY_OPERATING_LOOP.md
+  EVIDENCE_AND_SOURCE_INDEX.md
+  CURRICULUM_AND_LEARNING_PATHS.md
+  CONTRIBUTOR_ENTRYPOINTS.md
+  TRUST_ARCHITECTURE.md
   PROVENANCE_RECEIPTS.md
   PUBLICATION_PACK.md
 ```

--- a/docs/TRUST_ARCHITECTURE.md
+++ b/docs/TRUST_ARCHITECTURE.md
@@ -1,0 +1,71 @@
+# Trust Architecture
+
+NanoClaw's trust model is built from small public artifacts, explicit
+boundaries, and source-verifiable claims.
+
+## Layers
+
+| Layer | What proves it | Failure to avoid |
+| --- | --- | --- |
+| Evidence base | Source index, citations, verification states | Unsupported claims |
+| Education | Curriculum, modules, exercises, glossary | Opaque expert-only language |
+| Operations | Commits, PRs, issues, releases, monitoring notes | Activity without review trail |
+| Reputation | Consistent owner-authored releases and narrow external PRs | Noise, mass forks, generic outreach |
+| Entrypoints | Role-based docs and good first issues | Confusing or private-only onboarding |
+| Integration | PRs, issues, discussions, citations, feedback requests | Implied partnerships |
+| Ethics and legal boundaries | Human approval docs and publication pack | Hype, pricing claims, custody/yield language |
+
+## Trust Rules
+
+1. Public claims should point to public evidence.
+2. Research hypotheses should be labeled as hypotheses.
+3. Examples should use fake or placeholder data.
+4. Collection source assets should remain private until explicitly approved.
+5. Wallet, payment, minting, transfer, listing, DNS, donation, and pricing
+   actions require human approval.
+6. Legal, rights-clearance, custody, yield, investment, and partnership claims
+   require separate review.
+7. External projects should be approached through useful issues, discussions,
+   citations, and PRs, not broad outreach.
+
+## Reputation Signals
+
+Healthy signals:
+
+- owner-authored PRs;
+- clear release notes;
+- issues updated with concrete links;
+- docs that state what is not being claimed;
+- external PRs that fix one narrow gap;
+- source indexes that separate facts from interpretation.
+
+Weak signals:
+
+- empty forks;
+- generic "great project" comments;
+- speculative announcements;
+- implied partnerships;
+- private assets in public examples;
+- unreviewed legal or financial language.
+
+## Public Safety Checklist
+
+Before publishing, confirm:
+
+- no private media;
+- no buyer, collector, or partner private data;
+- no wallet data;
+- no API keys, webhook URLs, tokens, or local paths;
+- no pricing or guaranteed-value language;
+- no claims of custody, yield, investment performance, partnership,
+  endorsement, or rights clearance;
+- no source that has not been checked or clearly labeled.
+
+## Related Documents
+
+- `docs/EVIDENCE_AND_SOURCE_INDEX.md`
+- `docs/CURRICULUM_AND_LEARNING_PATHS.md`
+- `docs/CONTRIBUTOR_ENTRYPOINTS.md`
+- `docs/HUMAN_APPROVAL_BOUNDARIES.md`
+- `docs/PUBLICATION_PACK.md`
+- `docs/ECOSYSTEM_OPERATING_MODEL.md`

--- a/docs/WEEKLY_OPERATING_LOOP.md
+++ b/docs/WEEKLY_OPERATING_LOOP.md
@@ -10,6 +10,8 @@ small public improvements, safe research, and clear human approval boundaries.
 | Keep the repository alive | One small docs, schema, example, or issue update |
 | Maintain public trust | Releases and issues that explain what changed |
 | Learn from adjacent ecosystems | One local research note or mapping note |
+| Maintain the evidence base | One source verification or literature-index update |
+| Keep the education layer useful | One glossary, module, or exercise improvement |
 | Contribute externally with restraint | At most one precise docs-only PR when a real gap exists |
 | Protect private assets | Run public/private and secret scans before publishing |
 
@@ -40,7 +42,8 @@ small public improvements, safe research, and clear human approval boundaries.
 2. Update the relevant issue or release notes.
 3. Refresh the integration map and DeepTech queue.
 4. Review private/public boundaries for collection and NFT materials.
-5. Confirm no risky action happened without explicit human approval.
+5. Update the evidence/source index when a new claim is added.
+6. Confirm no risky action happened without explicit human approval.
 
 ## Human-Approved Actions
 


### PR DESCRIPTION
## Summary
- add evidence/source index with verification states and literature-index template
- add curriculum modules, exercises, and glossary
- add contributor entrypoints for students, developers, researchers, maintainers, partners, and collection collaborators
- add trust architecture covering evidence, education, operations, reputation, integration, and ethical/legal boundaries
- link the new docs from README, project status, ecosystem operating model, weekly loop, and publication pack

## Safety
- docs-only update
- no private collection assets
- no wallet data, webhook URLs, buyer data, payment details, pricing, or legal/financial claims
- explicitly reinforces no fake partnerships and no hype

## Checks
- git diff --check passes
- targeted secrets/private-data scan found only safety wording false positives